### PR TITLE
overlapping png and svgs and resizing of big number images

### DIFF
--- a/src/views/monitoring/Monitoring.vue
+++ b/src/views/monitoring/Monitoring.vue
@@ -40,6 +40,7 @@
         id="big-number-svg-5"
         class="big-number-map-locations-svg"
         alt=""
+        
         hidden
       />
     </div>
@@ -312,15 +313,32 @@
     //   }
     // }
 
- 
-#big-number-image-base {
+#monitoring-big-numbers-main-image-container  {
   position: relative;
-  z-index: 1;
+  width: 100%;
+  height: auto;
+
+  #big-number-image-base  {
+    display: block;
+    z-index: 1;
+
+  }
+
+  svg   {
+    position: absolute;
+    display: block;
+    width: 100%;
+    height: auto;
+    top: 0;
+    left:0;
+    z-index: 2;
+
+
+
+
+  }
 }
-.big-number-map-locations-svg {
-  position: absolute;
-  z-index: 2;
-}
+
     #monitoring {
 
         
@@ -332,7 +350,6 @@
 
           
           img {
-            
             position: absolute;
           }
 
@@ -342,24 +359,40 @@
             text-align: center;
             display: flex;
             flex-direction: row;
+            z-index: 1;
+
             .big-num{
               text-align: center;
               height: 100px;
               width: 100px;
-            }
-            .big-number-number {
+
+              img {
+              width: 30%;
+              z-index: -1;
+              left: 0;
+              align-items: left;
+              }
+              .big-number-number {
               
               // top: -50%;
               // left: 50%;
               // transform: translate(-50%, -100%);
               font-family: chantal, sans-serif;
               font-weight: bold;
-              color: green;
+              color: white;
+              z-index: 2;
+    
+            
+              }
+              
+
             }
+            
             .big-number-text {
               color: black;
               font-family: chantal, sans-serif;
               font-weight: bold;
+              z-index: -1;
               // position: absolute;
               // text-align: left;
               // top: 35%;


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

overlapping png and svgs and resizing of big number images
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
This should work. The scrolling for the big numbers section is much larger than the map though, could use attention.



After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial
