### PR TITLE
Start mobile layout

### DIFF
--- a/src/components/SankeyTransition.vue
+++ b/src/components/SankeyTransition.vue
@@ -179,20 +179,25 @@ export default {
     justify-items: center;
 
     #sankey-text-container {
+      z-index: 2;
       .sankey-text-and-title {
-        background-color: #04c585;
+        padding-top: 40em;
+      }
+      .text-content-side {
+        background-color: rgba(255,255,255, 0.75);
       }
     }
   }
 
   #sankey-image-container-outer {
-    background-color: #97d4ea;
+    z-index: 1;
+    position: sticky;
+    top: 0;
     grid-column: 1;
     grid-row: 1;
     align-self: start;
   }
   #sankey-text-container {
-    background-color: #d46e21;
     grid-column: 1;
     grid-row: 1;
     align-self: start;

--- a/src/components/SankeyTransition.vue
+++ b/src/components/SankeyTransition.vue
@@ -171,4 +171,31 @@ export default {
     opacity: 1;
   }
 }
+
+@media only screen and (max-width: 992px) {
+  #sankey-transition {
+    display: grid;
+    grid-template-columns: 1fr;
+    justify-items: center;
+
+    #sankey-text-container {
+      .sankey-text-and-title {
+        background-color: #04c585;
+      }
+    }
+  }
+
+  #sankey-image-container-outer {
+    background-color: #97d4ea;
+    grid-column: 1;
+    grid-row: 1;
+    align-self: start;
+  }
+  #sankey-text-container {
+    background-color: #d46e21;
+    grid-column: 1;
+    grid-row: 1;
+    align-self: start;
+  }
+}
 </style>


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome (windows 10) - works as expected
- [x] Safari (iPhone 11 iOS 13) -works as expected
- [x] Edge (Windows 10) -works as expected
- [x] Firefox (Ubuntu 18.04) -works as expected
- [ ] Samsung Internet (Galaxy S20 Android 10) - positioned too high in view port
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Make Sankey Transition Mobile
-----------
This uses a stacked CSS Grid to and a 920 px break point to layer the text onto the images. I tested this on a number of platforms there is an issue on Android where the sticky stops too high in the view port. Will look into that issue which might be related to the use of vh units in other sections. But it seems like this is a reasonable step forward to get on the board for review.   

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial
